### PR TITLE
Make ruby-guard play nicely with fuubar

### DIFF
--- a/ruby-guard.el
+++ b/ruby-guard.el
@@ -36,10 +36,10 @@
 
 (defun ruby-guard-command-name ()
   (cond ((ruby-guard-spring-p)
-         "spring guard")
+         "spring guard | cat")
         ((ruby-guard-bundle-p)
-         "bundle exec guard")
-        (t "guard")))
+         "bundle exec guard | cat")
+        (t "guard | cat")))
 
 (defmacro ruby-guard-with-root (body-form)
   `(let ((default-directory (ruby-guard-root)))


### PR DESCRIPTION
- https://github.com/thekompanee/fuubar is an rspec
  progress bar formatter that uses
  https://github.com/jfelchner/ruby-progressbar to format
  the line without a bunch of dots - just fills the screen
  The emacs _guard_ buffer didn't support the fancy
  cursor positioning and adding `|cat` to the command
  makes ruby-progressbar fallback to "nontty" mode.
