### PR TITLE
Run "chef exec guard" if in Chef cookbook and ChefDK installed.

### DIFF
--- a/ruby-guard.el
+++ b/ruby-guard.el
@@ -31,6 +31,14 @@
 (defun ruby-guard-zeus-p ()
   (file-exists-p (expand-file-name ".zeus.sock" (ruby-guard-root))))
 
+(defun ruby-guard-chef-cookbook-p ()
+  "Return non-nil if `ruby-guard-root' is in Chef cookbook."
+  (file-exists-p (expand-file-name "recipes" (ruby-guard-root))))
+
+(defun ruby-guard-chefdk-installed-p ()
+  "Return non-nil if Chef development kit directory is present."
+  (file-exists-p "/opt/chefdk"))
+
 (defun ruby-guard-bundle-p ()
   (file-exists-p (expand-file-name "Gemfile" (ruby-guard-root))))
 
@@ -39,6 +47,9 @@
          "spring guard")
         ((ruby-guard-bundle-p)
          "bundle exec guard")
+        ((and (ruby-guard-chef-cookbook-p)
+              (ruby-guard-chefdk-installed-p))
+         "chef exec guard")
         (t "guard")))
 
 (defmacro ruby-guard-with-root (body-form)


### PR DESCRIPTION
This adds tests for a Chef cookbook (looks for a "recipes" directory), and whether the Chef Development Kit (ChefDK) is installed (which is at "/opt/chefdk").  If so, it sets `ruby-guard-command`to "chef exec guard"; this is a ChefDK feature that executes a command within the Ruby environment it sets up.
